### PR TITLE
Fixed loss term and adjusted learning rate

### DIFF
--- a/gLasso_simu3/temp0.py
+++ b/gLasso_simu3/temp0.py
@@ -8,9 +8,6 @@ import csv
 import simu_data
 import numbers
 import argparse
-from tensorflow.python.framework import ops
-from tensorflow.python.ops import standard_ops
-import tensorlayer as tl
 from tensorflow.python.platform import tf_logging as logging
 from sklearn.metrics.pairwise import cosine_similarity
 
@@ -23,47 +20,52 @@ n = args.n
 rho = args.rho
 p = args.p
 
+
 def group2_regularizer(scale, scope=None):
+    if isinstance(scale, numbers.Integral):
+        raise ValueError('scale cannot be an integer: %s' % scale)
+    if isinstance(scale, numbers.Real):
+        if scale < 0.:
+            raise ValueError('Setting a scale less than 0 on a regularizer: %g' %
+                             scale)
+        if scale == 0.:
+            logging.info('Scale of 0 disables regularizer.')
+            return lambda _: None
 
-  if isinstance(scale, numbers.Integral):
-    raise ValueError('scale cannot be an integer: %s' % scale)
-  if isinstance(scale, numbers.Real):
-    if scale < 0.:
-      raise ValueError('Setting a scale less than 0 on a regularizer: %g' %
-                       scale)
-    if scale == 0.:
-      logging.info('Scale of 0 disables regularizer.')
-      return lambda _: None
+    def group2(weights, name=None):
+        """Applies group regularization to weights."""
+        with tf.name_scope(scope, 'group2_regularizer', [weights]) as name:
+            my_scale = tf.convert_to_tensor(scale,
+                                            dtype=weights.dtype.base_dtype,
+                                            name='scale')
+            return tf.multiply(
+                my_scale,
+                tf.reduce_sum(tf.sqrt(tf.reduce_sum(tf.square(weights), 1))),
+                name=name)
 
-  def group2(weights, name=None):
-    """Applies group regularization to weights."""
-    with ops.name_scope(scope, 'group2_regularizer', [weights]) as name:
-      my_scale = ops.convert_to_tensor(scale,
-                                       dtype=weights.dtype.base_dtype,
-                                       name='scale')
-      return standard_ops.multiply(
-          my_scale,
-          standard_ops.reduce_sum(standard_ops.sqrt(standard_ops.reduce_sum(tf.square(weights), 1))),
-          name=name)
-
-  return group2
+    return group2
 
 
 def gLasso_model(features, labels, mode, params):
-
-    net = tf.feature_column.input_layer(features, params['feature_columns'])
+    net = tf.feature_column.input_layer(features,
+                                        params['feature_columns'])
     if params['hidden_units'][0] == 0:
         regularizer = tf.contrib.layers.l1_regularizer(scale=params['reg'])
         response = tf.layers.dense(net, params['n_response'],
-                                   activation=None, kernel_regularizer=regularizer)
+                                   activation=None,
+                                   kernel_regularizer=regularizer)
     else:
         regularizer = group2_regularizer(scale=params['reg'])
-        net = tf.layers.dense(net, units=params['hidden_units'][0],
-                              activation=tf.nn.relu, kernel_regularizer=regularizer)
+        net = tf.layers.dense(net,
+                              units=params['hidden_units'][0],
+                              activation=tf.nn.relu,
+                              kernel_regularizer=regularizer)
         if len(params['hidden_units']) >= 2:
             for units in params['hidden_units'][1:]:
-                net = tf.layers.dense(net, units=units, activation=tf.nn.relu)
-        response = tf.layers.dense(net, params['n_response'], activation=None)
+                net = tf.layers.dense(net,
+                                      units=units, activation=tf.nn.relu)
+        response = tf.layers.dense(net, params['n_response'],
+                                   activation=None)
 
     response = tf.squeeze(response)
 
@@ -75,8 +77,9 @@ def gLasso_model(features, labels, mode, params):
         return tf.estimator.EstimatorSpec(mode, predictions=predictions)
 
     # Compute loss.
-    loss = tf.losses.mean_squared_error(labels=labels,
-                                        predictions=response)
+    mse_loss = tf.losses.mean_squared_error(labels=labels,
+                                            predictions=response)
+    loss = tf.losses.get_total_loss(add_regularization_losses=True)
 
     # Compute evaluation metrics.
     mse = tf.metrics.mean_squared_error(labels=labels,
@@ -91,14 +94,16 @@ def gLasso_model(features, labels, mode, params):
     # Create training op.
     assert mode == tf.estimator.ModeKeys.TRAIN
 
-    optimizer = tf.train.AdagradOptimizer(learning_rate=0.1)
-    train_op = optimizer.minimize(loss, global_step=tf.train.get_global_step())
+    optimizer = tf.train.AdagradOptimizer(learning_rate=0.01)
+    train_op = optimizer.minimize(loss,
+                                  global_step=tf.train.get_global_step())
 
-    return tf.estimator.EstimatorSpec(mode, loss=loss, train_op=train_op)
+    return tf.estimator.EstimatorSpec(mode,
+                                      loss=loss, train_op=train_op)
 
 
 N_runs = 20
-reg_factors = np.e**np.linspace(-10, 7, 10)
+reg_factors = np.exp(np.linspace(-10, 7, 10))
 # n_list = np.array([100, 200, 500, 1000])
 method_list = ["linear", "polynomial", "rbf"]
 # snr_list = np.array([2, 1.5])
@@ -136,7 +141,7 @@ for method in method_list:
             classifier.train(
                 input_fn=lambda: simu_data.train_input_fn(
                     train_x, train_y, 100),
-                steps=1500)
+                steps=10000)
 
             eval_result = classifier.evaluate(
                 input_fn=lambda: simu_data.eval_input_fn(test_x, test_y, 100))
@@ -157,9 +162,7 @@ for method in method_list:
             u0, s0, vh0 = np.linalg.svd(var_dict["dense/kernel"])
             hs_norm = np.linalg.norm(s0)
 
-
             add_info = [k, n, method, snr, rho, p, reg, cos_dis, eval_result['MSE'], spec_norm, hs_norm]
             writer.writerow(add_info)
             print(add_info)
 csvFile0.close()
-

--- a/gLasso_simu3/temp1.py
+++ b/gLasso_simu3/temp1.py
@@ -8,9 +8,6 @@ import csv
 import simu_data
 import numbers
 import argparse
-from tensorflow.python.framework import ops
-from tensorflow.python.ops import standard_ops
-import tensorlayer as tl
 from tensorflow.python.platform import tf_logging as logging
 from sklearn.metrics.pairwise import cosine_similarity
 
@@ -23,34 +20,33 @@ n = args.n
 rho = args.rho
 p = args.p
 
+
 def group2_regularizer(scale, scope=None):
+    if isinstance(scale, numbers.Integral):
+        raise ValueError('scale cannot be an integer: %s' % scale)
+    if isinstance(scale, numbers.Real):
+        if scale < 0.:
+            raise ValueError('Setting a scale less than 0 on a regularizer: %g' %
+                             scale)
+        if scale == 0.:
+            logging.info('Scale of 0 disables regularizer.')
+            return lambda _: None
 
-  if isinstance(scale, numbers.Integral):
-    raise ValueError('scale cannot be an integer: %s' % scale)
-  if isinstance(scale, numbers.Real):
-    if scale < 0.:
-      raise ValueError('Setting a scale less than 0 on a regularizer: %g' %
-                       scale)
-    if scale == 0.:
-      logging.info('Scale of 0 disables regularizer.')
-      return lambda _: None
+    def group2(weights, name=None):
+        """Applies group regularization to weights."""
+        with tf.name_scope(scope, 'group2_regularizer', [weights]) as name:
+            my_scale = tf.convert_to_tensor(scale,
+                                            dtype=weights.dtype.base_dtype,
+                                            name='scale')
+            return tf.multiply(
+                my_scale,
+                tf.reduce_sum(tf.sqrt(tf.reduce_sum(tf.square(weights), 1))),
+                name=name)
 
-  def group2(weights, name=None):
-    """Applies group regularization to weights."""
-    with ops.name_scope(scope, 'group2_regularizer', [weights]) as name:
-      my_scale = ops.convert_to_tensor(scale,
-                                       dtype=weights.dtype.base_dtype,
-                                       name='scale')
-      return standard_ops.multiply(
-          my_scale,
-          standard_ops.reduce_sum(standard_ops.sqrt(standard_ops.reduce_sum(tf.square(weights), 1))),
-          name=name)
-
-  return group2
+    return group2
 
 
 def gLasso_model(features, labels, mode, params):
-
     net = tf.feature_column.input_layer(features, params['feature_columns'])
     if params['hidden_units'][0] == 0:
         regularizer = tf.contrib.layers.l1_regularizer(scale=params['reg'])
@@ -75,8 +71,9 @@ def gLasso_model(features, labels, mode, params):
         return tf.estimator.EstimatorSpec(mode, predictions=predictions)
 
     # Compute loss.
-    loss = tf.losses.mean_squared_error(labels=labels,
-                                        predictions=response)
+    mse_loss = tf.losses.mean_squared_error(labels=labels,
+                                            predictions=response)
+    loss = tf.losses.get_total_loss(add_regularization_losses=True)
 
     # Compute evaluation metrics.
     mse = tf.metrics.mean_squared_error(labels=labels,
@@ -91,20 +88,20 @@ def gLasso_model(features, labels, mode, params):
     # Create training op.
     assert mode == tf.estimator.ModeKeys.TRAIN
 
-    optimizer = tf.train.AdagradOptimizer(learning_rate=0.1)
+    optimizer = tf.train.AdagradOptimizer(learning_rate=0.01)
     train_op = optimizer.minimize(loss, global_step=tf.train.get_global_step())
 
     return tf.estimator.EstimatorSpec(mode, loss=loss, train_op=train_op)
 
 
 N_runs = 20
-reg_factors = np.e**np.linspace(-10, 7, 10)
+reg_factors = np.e ** np.linspace(-10, 7, 10)
 # n_list = np.array([100, 200, 500, 1000])
 method_list = ["linear", "polynomial", "rbf"]
 # snr_list = np.array([2, 1.5])
 # rho_list = np.array([0, .2])
 # p_list = np.array([20, 50, 100])
-snr = 2
+snr = 2.
 
 ## layers = 1
 csvFile1 = open("result1.csv", "a")
@@ -136,7 +133,7 @@ for method in method_list:
             classifier.train(
                 input_fn=lambda: simu_data.train_input_fn(
                     train_x, train_y, 100),
-                steps=1500)
+                steps=10000)
 
             eval_result = classifier.evaluate(
                 input_fn=lambda: simu_data.eval_input_fn(test_x, test_y, 100))
@@ -163,4 +160,3 @@ for method in method_list:
             writer.writerow(add_info)
             print(add_info)
 csvFile1.close()
-

--- a/gLasso_simu3/temp2.py
+++ b/gLasso_simu3/temp2.py
@@ -8,9 +8,6 @@ import csv
 import simu_data
 import numbers
 import argparse
-from tensorflow.python.framework import ops
-from tensorflow.python.ops import standard_ops
-import tensorlayer as tl
 from tensorflow.python.platform import tf_logging as logging
 from sklearn.metrics.pairwise import cosine_similarity
 
@@ -23,34 +20,33 @@ n = args.n
 rho = args.rho
 p = args.p
 
+
 def group2_regularizer(scale, scope=None):
+    if isinstance(scale, numbers.Integral):
+        raise ValueError('scale cannot be an integer: %s' % scale)
+    if isinstance(scale, numbers.Real):
+        if scale < 0.:
+            raise ValueError('Setting a scale less than 0 on a regularizer: %g' %
+                             scale)
+        if scale == 0.:
+            logging.info('Scale of 0 disables regularizer.')
+            return lambda _: None
 
-  if isinstance(scale, numbers.Integral):
-    raise ValueError('scale cannot be an integer: %s' % scale)
-  if isinstance(scale, numbers.Real):
-    if scale < 0.:
-      raise ValueError('Setting a scale less than 0 on a regularizer: %g' %
-                       scale)
-    if scale == 0.:
-      logging.info('Scale of 0 disables regularizer.')
-      return lambda _: None
+    def group2(weights, name=None):
+        """Applies group regularization to weights."""
+        with tf.name_scope(scope, 'group2_regularizer', [weights]) as name:
+            my_scale = tf.convert_to_tensor(scale,
+                                            dtype=weights.dtype.base_dtype,
+                                            name='scale')
+            return tf.multiply(
+                my_scale,
+                tf.reduce_sum(tf.sqrt(tf.reduce_sum(tf.square(weights), 1))),
+                name=name)
 
-  def group2(weights, name=None):
-    """Applies group regularization to weights."""
-    with ops.name_scope(scope, 'group2_regularizer', [weights]) as name:
-      my_scale = ops.convert_to_tensor(scale,
-                                       dtype=weights.dtype.base_dtype,
-                                       name='scale')
-      return standard_ops.multiply(
-          my_scale,
-          standard_ops.reduce_sum(standard_ops.sqrt(standard_ops.reduce_sum(tf.square(weights), 1))),
-          name=name)
-
-  return group2
+    return group2
 
 
 def gLasso_model(features, labels, mode, params):
-
     net = tf.feature_column.input_layer(features, params['feature_columns'])
     if params['hidden_units'][0] == 0:
         regularizer = tf.contrib.layers.l1_regularizer(scale=params['reg'])
@@ -75,8 +71,9 @@ def gLasso_model(features, labels, mode, params):
         return tf.estimator.EstimatorSpec(mode, predictions=predictions)
 
     # Compute loss.
-    loss = tf.losses.mean_squared_error(labels=labels,
-                                        predictions=response)
+    mse_loss = tf.losses.mean_squared_error(labels=labels,
+                                            predictions=response)
+    loss = tf.losses.get_total_loss(add_regularization_losses=True)
 
     # Compute evaluation metrics.
     mse = tf.metrics.mean_squared_error(labels=labels,
@@ -91,14 +88,14 @@ def gLasso_model(features, labels, mode, params):
     # Create training op.
     assert mode == tf.estimator.ModeKeys.TRAIN
 
-    optimizer = tf.train.AdagradOptimizer(learning_rate=0.1)
+    optimizer = tf.train.AdagradOptimizer(learning_rate=0.01)
     train_op = optimizer.minimize(loss, global_step=tf.train.get_global_step())
 
     return tf.estimator.EstimatorSpec(mode, loss=loss, train_op=train_op)
 
 
 N_runs = 20
-reg_factors = np.e**np.linspace(-10, 7, 10)
+reg_factors = np.e ** np.linspace(-10, 7, 10)
 # n_list = np.array([100, 200, 500, 1000])
 method_list = ["linear", "polynomial", "rbf"]
 # snr_list = np.array([2, 1.5])
@@ -136,7 +133,7 @@ for method in method_list:
             classifier.train(
                 input_fn=lambda: simu_data.train_input_fn(
                     train_x, train_y, 100),
-                steps=1500)
+                steps=10000)
 
             eval_result = classifier.evaluate(
                 input_fn=lambda: simu_data.eval_input_fn(test_x, test_y, 100))
@@ -165,4 +162,3 @@ for method in method_list:
             writer.writerow(add_info)
             print(add_info)
 csvFile2.close()
-


### PR DESCRIPTION
Aside from minor changes with respect to coding style:

- Redefined loss as `loss = tf.losses.get_total_loss(add_regularization_losses=True)`. So the regularization loss is also passed to optimizer.
- Changed step size to 0.01, and increased total training steps to 1e5
 